### PR TITLE
Add README and backup script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Variaveis de ambiente para OpenEMR
+# Copie este arquivo para .env e defina senhas seguras
+MYSQL_ROOT_PASSWORD=troque_esta_senha_root
+MYSQL_USER=openemr
+MYSQL_PASS=troque_esta_senha
+OE_USER=admin
+OE_PASS=troque_esta_senha_admin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Lint Docker Compose file
       run: |
-        docker-compose -f docker-compose.yml config
+        docker-compose --env-file .env.example -f docker-compose.yml config
 
     - name: Install ShellCheck
       run: sudo apt-get update && sudo apt-get install -y shellcheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+backups/

--- a/README-Saraiva-Vision.md
+++ b/README-Saraiva-Vision.md
@@ -119,10 +119,14 @@ docker-compose logs -f certbot
 docker-compose run --rm certbot renew
 
 # Backup dos dados
-docker-compose exec mysql mysqldump -u openemr -p openemr > backup_saraiva_vision.sql
+Utilize o script `backup.sh` para gerar dumps do banco de dados em `./backups`:
 
-# Restaurar backup
-docker-compose exec -i mysql mysql -u openemr -p openemr < backup_saraiva_vision.sql
+```bash
+./backup.sh
+```
+
+# Restaurar backup manualmente
+docker-compose exec -i mysql mysql -u "$MYSQL_USER" -p"$MYSQL_PASS" openemr < caminho/para/arquivo.sql
 ```
 **Note:** The `ssl/` directory with self-signed certificates is no longer used by default if Let's Encrypt is active. It can be kept for fallback or local-only development if Nginx config is adjusted.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# OpenEMR Docker Setup
+
+This repository provides a simple Docker Compose configuration for [OpenEMR](https://www.open-emr.org/). Nginx acts as a reverse proxy with Let's Encrypt support.
+
+## Getting Started
+
+1. Copy `.env.example` to `.env` and set strong passwords for the database and initial OpenEMR user.
+2. Start the services:
+   ```bash
+   docker-compose up -d
+   ```
+3. Generate the Let's Encrypt certificate (replace the email address if needed):
+   ```bash
+   docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot \
+       --email you@example.com --agree-tos --no-eff-email \
+       -d emr.saraivavision.com.br
+   docker-compose restart nginx
+   ```
+4. Access `https://emr.saraivavision.com.br` and complete the setup wizard.
+
+## Backup
+
+Use the `backup.sh` script to create database dumps in the `./backups` directory.
+
+```bash
+./backup.sh
+```
+
+Schedule this script with `cron` to run daily.
+
+## Security Notes
+
+- Passwords are stored in the `.env` file, which is ignored by Git.
+- The Nginx configuration includes security headers and enforces HTTPS.
+- Keep containers and images up to date.
+
+## Useful Commands
+
+- Start/update services: `docker-compose up -d`
+- Stop services: `docker-compose down`
+- View logs: `docker-compose logs -f`
+
+For more detailed instructions, see `README-Saraiva-Vision.md`.

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Script simples para gerar backups do banco de dados OpenEMR
+# Uso: ./backup.sh
+# Os arquivos de backup serao armazenados em ./backups
+set -e
+BACKUP_DIR="$(dirname "$0")/backups"
+mkdir -p "$BACKUP_DIR"
+DATE=$(date +%F-%H%M%S)
+FILE="$BACKUP_DIR/openemr-$DATE.sql"
+
+docker-compose exec -T mysql mysqldump -u"$MYSQL_USER" -p"$MYSQL_PASS" openemr > "$FILE"
+echo "Backup criado em $FILE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
     - databasevolume:/var/lib/mysql
     environment:
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
 
   openemr:
     restart: always
@@ -18,11 +18,11 @@ services:
     - sitevolume:/var/www/localhost/htdocs/openemr/sites
     environment:
       MYSQL_HOST: mysql
-      MYSQL_ROOT_PASS: root
-      MYSQL_USER: openemr
-      MYSQL_PASS: openemr
-      OE_USER: admin
-      OE_PASS: pass
+      MYSQL_ROOT_PASS: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASS: ${MYSQL_PASS}
+      OE_USER: ${OE_USER}
+      OE_PASS: ${OE_PASS}
     depends_on:
     - mysql
 

--- a/knowledge.md
+++ b/knowledge.md
@@ -6,7 +6,7 @@ This project sets up OpenEMR for Clínica Saraiva Vision using Docker Compose. I
 
 ## Key Files
 
-- `docker-compose.yml`: Defines the services (OpenEMR, MySQL, Nginx, Certbot).
+- `docker-compose.yml`: Defines the services (OpenEMR, MySQL, Nginx, Certbot). Uses variables from `.env`.
 - `nginx/nginx.conf`: Nginx configuration for reverse proxy, SSL, and Let's Encrypt challenges.
 - `saraiva-vision-setup.sh`: Script to initialize the Docker containers (primarily for initial setup).
 - `README-Saraiva-Vision.md`: Detailed setup and usage instructions.
@@ -109,6 +109,7 @@ This section outlines a potential CI/CD strategy for this project.
 ### Considerations for Production:
 -   **Secrets Management:** Securely manage passwords (e.g., `MYSQL_ROOT_PASSWORD`, `OE_PASS`) using CI/CD environment variables or a secrets manager, rather than hardcoding in `docker-compose.yml` for production.
 -   **Database Migrations:** OpenEMR handles its own schema. Backups are crucial.
+-   Use the `backup.sh` script or another backup tool to export the database regularly.
 -   **SSL Certificates:** Now managed by Let's Encrypt. Ensure renewal process is monitored.
 -   **Downtime:** `docker-compose up -d` can cause brief downtime. For zero-downtime, consider blue/green deployments or load balancing with multiple instances.
 -   **Monitoring & Logging:** Implement robust monitoring and centralized logging for production.


### PR DESCRIPTION
## Summary
- add documentation with new README
- add backup script and ignore backups
- parameterize credentials via `.env` file
- update workflow to use env file
- document backup instructions in existing docs

## Testing
- `shellcheck saraiva-vision-setup.sh backup.sh`
- `docker-compose --env-file .env.example -f docker-compose.yml config`

------
https://chatgpt.com/codex/tasks/task_e_683f45256ecc83289a0808608812cc21