### PR TITLE
Add CouchDB support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ MYSQL_USER=openemr
 MYSQL_PASS=troque_esta_senha
 OE_USER=admin
 OE_PASS=troque_esta_senha_admin
+COUCHDB_USER=admin
+COUCHDB_PASSWORD=troque_esta_senha_couchdb

--- a/README-Saraiva-Vision.md
+++ b/README-Saraiva-Vision.md
@@ -4,7 +4,8 @@
 
 ### 1. Prerequisites
 - A domain name (e.g., `emr.saraivavision.com.br`) pointing to your server's public IP address.
-- Ports 80 and 443 open on your server.
+- Ports 80, 443 and 5984 open on your server.
+- CouchDB is used to store documents and listens on port 5984.
 
 ### 2. Initial Setup Script
 The `saraiva-vision-setup.sh` script can be used to bring up the containers initially.
@@ -114,6 +115,8 @@ docker-compose logs -f nginx
 
 # Ver logs do certbot
 docker-compose logs -f certbot
+# Ver logs do CouchDB
+docker-compose logs -f couchdb
 
 # Manually renew certificates (usually not needed)
 docker-compose run --rm certbot renew
@@ -124,6 +127,7 @@ Utilize o script `backup.sh` para gerar dumps do banco de dados em `./backups`:
 ```bash
 ./backup.sh
 ```
+O script também gera um arquivo compactado com os dados do CouchDB.
 
 # Restaurar backup manualmente
 docker-compose exec -i mysql mysql -u "$MYSQL_USER" -p"$MYSQL_PASS" openemr < caminho/para/arquivo.sql

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository provides a simple Docker Compose configuration for [OpenEMR](htt
 
 ## Getting Started
 
-1. Copy `.env.example` to `.env` and set strong passwords for the database and initial OpenEMR user.
+1. Copy `.env.example` to `.env` and set strong passwords for the database, CouchDB and the initial OpenEMR user.
 2. Start the services:
    ```bash
    docker-compose up -d
@@ -33,10 +33,14 @@ data/
   db/             # MariaDB data
   logs/           # OpenEMR logs
   openemr_sites/  # Persistent OpenEMR site data
+  couchdb/        # CouchDB data for documents
   certbot/
     certs/        # Let's Encrypt certificates
     www/          # ACME challenge files
 ```
+
+CouchDB is included as a document database and listens on port `5984`.
+Credentials are configured via `.env`.
 
 ## Backup
 
@@ -59,6 +63,7 @@ Schedule this script with `cron` to run daily.
 - Start/update services: `docker-compose up -d`
 - Stop services: `docker-compose down`
 - View logs: `docker-compose logs -f`
+- Access CouchDB: `http://localhost:5984` (credentials from `.env`)
 
 ## CI/CD
 

--- a/backup.sh
+++ b/backup.sh
@@ -7,6 +7,10 @@ BACKUP_DIR="$(dirname "$0")/backups"
 mkdir -p "$BACKUP_DIR"
 DATE=$(date +%F-%H%M%S)
 FILE="$BACKUP_DIR/openemr-$DATE.sql"
+COUCHFILE="$BACKUP_DIR/couchdb-$DATE.tar.gz"
 
 docker-compose exec -T mysql mysqldump -u"$MYSQL_USER" -p"$MYSQL_PASS" openemr > "$FILE"
 echo "Backup criado em $FILE"
+docker-compose exec couchdb tar -czf - /opt/couchdb/data > "$COUCHFILE"
+echo "Backup CouchDB criado em $COUCHFILE"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,17 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
 
+  couchdb:
+    restart: always
+    image: couchdb:3
+    ports:
+      - "5984:5984"
+    volumes:
+      - ./data/couchdb:/opt/couchdb/data
+    environment:
+      COUCHDB_USER: ${COUCHDB_USER}
+      COUCHDB_PASSWORD: ${COUCHDB_PASSWORD}
+
   openemr:
     restart: always
     image: openemr/openemr:7.0.3
@@ -25,6 +36,7 @@ services:
       OE_PASS: ${OE_PASS}
     depends_on:
     - mysql
+    - couchdb
 
   nginx:
     restart: always

--- a/knowledge.md
+++ b/knowledge.md
@@ -6,7 +6,7 @@ This project sets up OpenEMR for Clínica Saraiva Vision using Docker Compose. I
 
 ## Key Files
 
-- `docker-compose.yml`: Defines the services (OpenEMR, MySQL, Nginx, Certbot). Uses variables from `.env`.
+- `docker-compose.yml`: Defines the services (OpenEMR, MySQL, CouchDB, Nginx, Certbot). Uses variables from `.env`.
 - `docker/nginx/nginx.conf`: Nginx configuration for reverse proxy, SSL, and Let's Encrypt challenges.
 - `saraiva-vision-setup.sh`: Script to initialize the Docker containers (primarily for initial setup).
 - `README-Saraiva-Vision.md`: Detailed setup and usage instructions.


### PR DESCRIPTION
## Summary
- include CouchDB service in `docker-compose.yml`
- provide credentials for CouchDB in `.env.example`
- document new service in README files
- extend backup script to dump CouchDB volume
- keep empty CouchDB data directory tracked

## Testing
- `docker-compose --env-file .env.example -f docker-compose.yml config` *(fails: docker-compose not found)*
- `shellcheck saraiva-vision-setup.sh update.sh backup.sh` *(fails: shellcheck not found)*

------
https://chatgpt.com/codex/tasks/task_e_684049bf41a083289d2d99a194f75d51