### PR TITLE
Configure PHP sessions to use Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenEMR Docker Setup
 
-This repository provides a simple Docker Compose configuration for [OpenEMR](https://www.open-emr.org/). Nginx acts as a reverse proxy with Let's Encrypt support.
+This repository provides a simple Docker Compose configuration for [OpenEMR](https://www.open-emr.org/). Nginx acts as a reverse proxy with Let's Encrypt support and Redis is used for PHP session storage.
 
 ## Getting Started
 
@@ -9,6 +9,7 @@ This repository provides a simple Docker Compose configuration for [OpenEMR](htt
    ```bash
    docker-compose up -d
    ```
+   The Redis service will automatically be used by PHP to store sessions.
 3. Generate the Let's Encrypt certificate (replace the email address if needed):
    ```bash
    docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot \
@@ -29,6 +30,7 @@ This repository provides a simple Docker Compose configuration for [OpenEMR](htt
 docker/
   nginx/          # Nginx configuration
   ssl/            # Optional self‑signed certificates
+  php/            # Additional PHP configuration (Redis sessions)
 data/
   db/             # MariaDB data
   logs/           # OpenEMR logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
     - ./data/logs:/var/log
     - ./data/openemr_sites:/var/www/localhost/htdocs/openemr/sites
+    - ./docker/php/redis-session.ini:/usr/local/etc/php/conf.d/redis-session.ini:ro
     environment:
       MYSQL_HOST: mysql
       MYSQL_ROOT_PASS: ${MYSQL_ROOT_PASSWORD}
@@ -25,6 +26,7 @@ services:
       OE_PASS: ${OE_PASS}
     depends_on:
     - mysql
+    - redis
 
   nginx:
     restart: always
@@ -48,4 +50,8 @@ services:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
     depends_on:
       - nginx
+
+  redis:
+    image: redis:7-alpine
+    restart: always
 

--- a/docker/php/redis-session.ini
+++ b/docker/php/redis-session.ini
@@ -1,0 +1,2 @@
+session.save_handler = redis
+session.save_path = "tcp://redis:6379"


### PR DESCRIPTION
## Summary
- add Redis PHP session configuration and service
- mount Redis session ini into OpenEMR container
- document Redis sessions in README

## Testing
- `docker-compose --env-file .env.example -f docker-compose.yml config` *(fails: command not found)*
- `shellcheck saraiva-vision-setup.sh update.sh backup.sh`
- `./backup.sh` *(fails: command not found)*
- `curl -f http://localhost` *(fails: couldn't connect)*

------
https://chatgpt.com/codex/tasks/task_e_68404b065c1c8328b0ff02732d4b8d0a