### PR TITLE
Add firewall and log monitoring scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,25 @@ Schedule this script with `cron` to run daily.
 - Passwords are stored in the `.env` file, which is ignored by Git.
 - The Nginx configuration includes security headers and enforces HTTPS.
 - Keep containers and images up to date.
+## Firewall Setup
+
+Run `./firewall-setup.sh` as root to open ports 80 and 443 for the Docker containers.
+
 
 ## Useful Commands
 
 - Start/update services: `docker-compose up -d`
 - Stop services: `docker-compose down`
 - View logs: `docker-compose logs -f`
+
+## Log Monitoring with OpenAI
+
+Use `log-monitor-openai.sh` to summarize container logs with the OpenAI API.
+This script uses the `gpt-4o` model for more accurate summaries.
+Set `OPENAI_API_KEY` and run:
+```bash
+OPENAI_API_KEY=your_key ./log-monitor-openai.sh
+```
 
 ## CI/CD
 

--- a/firewall-setup.sh
+++ b/firewall-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Configure basic firewall rules for the Docker containers
+# Opens HTTP and HTTPS ports used by Nginx reverse proxy
+set -e
+
+# Require sudo for firewall commands
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Please run as root or with sudo" >&2
+  exit 1
+fi
+
+# Allow SSH so we do not lock ourselves out
+iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+
+# Allow HTTP and HTTPS for the reverse proxy
+iptables -A INPUT -p tcp --dport 80 -j ACCEPT
+iptables -A INPUT -p tcp --dport 443 -j ACCEPT
+
+# Allow established connections and localhost
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A INPUT -i lo -j ACCEPT
+
+# Drop everything else by default
+iptables -P INPUT DROP
+
+echo "Firewall rules applied: ports 80 and 443 open"

--- a/log-monitor-openai.sh
+++ b/log-monitor-openai.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Monitor Docker logs and ask OpenAI's API for a summary of potential errors
+set -e
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "OPENAI_API_KEY environment variable not set" >&2
+  exit 1
+fi
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+
+LOG_FILE="./logs/docker.log"
+mkdir -p ./logs
+
+echo "Collecting container logs..."
+docker-compose logs --no-color > "$LOG_FILE"
+
+# Take the last 200 lines for analysis
+LOG_DATA=$(tail -n 200 "$LOG_FILE" | sed 's/"/\\"/g')
+
+read -r -d '' PAYLOAD <<JSON
+{
+  "model": "gpt-4o",
+  "messages": [
+    {"role": "user", "content": "Analise os logs a seguir e forne\u00e7a um resumo de poss\u00edveis erros:\n$LOG_DATA"}
+  ]
+}
+JSON
+
+echo "Enviando logs para OpenAI..."
+
+curl -s https://api.openai.com/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d "$PAYLOAD" | jq -r '.choices[0].message.content'


### PR DESCRIPTION
## Summary
- add `firewall-setup.sh` to configure iptables rules for docker ports
- add `log-monitor-openai.sh` to send container logs to OpenAI for analysis
- document new scripts in `README.md`
- switch log-monitoring script to use `gpt-4o`

## Testing
- `docker-compose --env-file .env.example -f docker-compose.yml config` *(fails: command not found)*
- `shellcheck saraiva-vision-setup.sh update.sh backup.sh firewall-setup.sh log-monitor-openai.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407bcad99083288dfe337922be894b