### PR TITLE
Configure PHP sessions to use Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenEMR Docker Setup
 
-This repository provides a simple Docker Compose configuration for [OpenEMR](https://www.open-emr.org/). Nginx acts as a reverse proxy with Let's Encrypt support.
+This repository provides a simple Docker Compose configuration for [OpenEMR](https://www.open-emr.org/). Nginx acts as a reverse proxy with Let's Encrypt support and Redis is used for PHP session storage.
 
 ## Getting Started
 
@@ -9,6 +9,7 @@ This repository provides a simple Docker Compose configuration for [OpenEMR](htt
    ```bash
    docker-compose up -d
    ```
+   The Redis service will automatically be used by PHP to store sessions.
 3. Generate the Let's Encrypt certificate (replace the email address if needed):
    ```bash
    docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot \
@@ -29,9 +30,10 @@ This repository provides a simple Docker Compose configuration for [OpenEMR](htt
 docker/
   nginx/          # Nginx configuration
   ssl/            # Optional self‑signed certificates
+  php/            # Additional PHP configuration (Redis sessions)
 data/
   db/             # MariaDB data
-  logs/           # OpenEMR logs
+  logs/           # OpenEMR logs (rotated via docker-compose logging options)
   openemr_sites/  # Persistent OpenEMR site data
   certbot/
     certs/        # Let's Encrypt certificates
@@ -59,6 +61,8 @@ Schedule this script with `cron` to run daily.
 - Start/update services: `docker-compose up -d`
 - Stop services: `docker-compose down`
 - View logs: `docker-compose logs -f`
+  The services use Docker's JSON log driver with rotation (10MB, 3 files).
+  Application logs from OpenEMR are also written to `data/logs`.
 
 ## CI/CD
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,22 @@ services:
     image: mariadb:11.4
     command: ['mariadbd','--character-set-server=utf8mb4']
     volumes:
-    - ./data/db:/var/lib/mysql
+      - ./data/db:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   openemr:
     restart: always
     image: openemr/openemr:7.0.3
     volumes:
-    - ./data/logs:/var/log
-    - ./data/openemr_sites:/var/www/localhost/htdocs/openemr/sites
+      - ./data/logs:/var/log
+      - ./data/openemr_sites:/var/www/localhost/htdocs/openemr/sites
+      - ./docker/php/redis-session.ini:/usr/local/etc/php/conf.d/redis-session.ini:ro
     environment:
       MYSQL_HOST: mysql
       MYSQL_ROOT_PASS: ${MYSQL_ROOT_PASSWORD}
@@ -24,20 +30,31 @@ services:
       OE_USER: ${OE_USER}
       OE_PASS: ${OE_PASS}
     depends_on:
-    - mysql
+      - mysql
+      - redis
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   nginx:
     restart: always
     image: nginx:alpine
     ports:
-    - 80:80
-    - 443:443
+      - 80:80
+      - 443:443
     volumes:
-    - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-    - ./data/certbot/certs:/etc/letsencrypt
-    - ./data/certbot/www:/var/www/certbot
+      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./data/certbot/certs:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
     depends_on:
-    - openemr
+      - openemr
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   certbot:
     image: certbot/certbot
@@ -48,4 +65,18 @@ services:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
     depends_on:
       - nginx
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 

--- a/docker/php/redis-session.ini
+++ b/docker/php/redis-session.ini
@@ -1,0 +1,2 @@
+session.save_handler = redis
+session.save_path = "tcp://redis:6379"


### PR DESCRIPTION
## Summary
- add Redis PHP session configuration and service
- mount Redis session ini into OpenEMR container
- rotate container logs via docker-compose and document logging

## Testing
- `docker-compose --env-file .env.example -f docker-compose.yml config` *(fails: command not found)*
- `shellcheck saraiva-vision-setup.sh update.sh backup.sh`
- `./backup.sh` *(fails: command not found)*
- `curl -f http://localhost` *(fails: couldn't connect)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68404b065c1c8328b0ff02732d4b8d0a