### PR TITLE
Add rclone upload option for backups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ MYSQL_USER=openemr
 MYSQL_PASS=troque_esta_senha
 OE_USER=admin
 OE_PASS=troque_esta_senha_admin
+# Opcional: destino remoto rclone para backups
+# Exemplo: RCLONE_REMOTE=s3:meubucket/backups
+#RCLONE_REMOTE=

--- a/README-Ophthalmology.md
+++ b/README-Ophthalmology.md
@@ -121,7 +121,15 @@ docker-compose run --rm certbot renew
 
 ## Backup e Restauração de Dados
 
+Para gerar um backup local execute:
 
+```bash
+./backup.sh
+```
+
+Se a variável `RCLONE_REMOTE` estiver definida e o [rclone](https://rclone.org)
+estiver configurado, o arquivo será enviado para o destino especificado
+(exemplo: `s3:meubucket/backups`).
 
 Para restaurar um backup existente (substitua `arquivo_de_backup.sql.gz` pelo nome do arquivo desejado):
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Use the `backup.sh` script to create database dumps in the `./backups` directory
 ```bash
 ./backup.sh
 ```
+Set the `RCLONE_REMOTE` environment variable to automatically upload the
+generated file using [rclone](https://rclone.org). The value should be a
+configured remote path such as `s3:mybucket/backups`.
 
 Schedule this script with `cron` to run daily.
 

--- a/backup.sh
+++ b/backup.sh
@@ -15,6 +15,9 @@ abort() {
 }
 
 command -v docker-compose >/dev/null 2>&1 || abort "docker-compose nao encontrado"
+if [ -n "${RCLONE_REMOTE:-}" ]; then
+    command -v rclone >/dev/null 2>&1 || abort "rclone nao encontrado"
+fi
 
 BACKUP_DIR="${BACKUP_DIR:-$(dirname "$0")/backups}"
 mkdir -p "$BACKUP_DIR"
@@ -23,6 +26,13 @@ FILE="$BACKUP_DIR/openemr-$DATE.sql"
 
 if docker-compose exec -T mysql mysqldump -u"${MYSQL_USER:-openemr}" -p"${MYSQL_PASS:-openemr}" openemr > "$FILE"; then
     log "Backup criado em $FILE"
+    if [ -n "${RCLONE_REMOTE:-}" ]; then
+        if rclone copy "$FILE" "$RCLONE_REMOTE"; then
+            log "Backup enviado para $RCLONE_REMOTE"
+        else
+            abort "Falha ao enviar backup remoto"
+        fi
+    fi
 else
     abort "Falha ao criar backup"
 fi

--- a/tests/backup.sh
+++ b/tests/backup.sh
@@ -25,4 +25,14 @@ chmod +x "$TMP/bin/docker-compose"
 PATH="$(pwd)/$TMP/bin:$PATH" BACKUP_DIR="$(pwd)/$TMP/backups" MYSQL_USER=u MYSQL_PASS=p ./backup.sh >"$TMP/out" 2>&1
 [ -n "$(ls -A "$TMP/backups")" ]
 
+# Test: uploads backup when RCLONE_REMOTE is set
+cat <<STUB > "$TMP/bin/rclone"
+#!/bin/bash
+echo "$@" > "$TMP/rclone_args"
+exit 0
+STUB
+chmod +x "$TMP/bin/rclone"
+PATH="$(pwd)/$TMP/bin:$PATH" BACKUP_DIR="$(pwd)/$TMP/backups" MYSQL_USER=u MYSQL_PASS=p RCLONE_REMOTE="remote:dest" ./backup.sh >"$TMP/out" 2>&1
+grep -q "remote:dest" "$TMP/rclone_args"
+
 echo "backup.sh tests passed"


### PR DESCRIPTION
## Summary
- support optional remote uploads via rclone in `backup.sh`
- document new `RCLONE_REMOTE` option in README and README-Ophthalmology
- mention rclone setting in `.env.example`
- test rclone integration in `tests/backup.sh`

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68408d6ba588832894e383caf6269542