### PR TITLE
Improve docker compose compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Lint Docker Compose file
       run: |
-        docker-compose --env-file .env.example -f docker-compose.yml config
+        docker compose --env-file .env.example -f docker-compose.yml config
 
     - name: Install ShellCheck
       run: sudo apt-get update && sudo apt-get install -y shellcheck
@@ -27,8 +27,8 @@ jobs:
 
     - name: Run smoke tests
       run: |
-        docker-compose --env-file .env.example up -d
+        docker compose --env-file .env.example up -d
         sleep 30
         ./backup.sh
-        curl -f http://localhost || (docker-compose logs; exit 1)
-        docker-compose down
+        curl -f http://localhost || (docker compose logs; exit 1)
+        docker compose down

--- a/backup.sh
+++ b/backup.sh
@@ -14,7 +14,17 @@ abort() {
     exit 1
 }
 
-command -v docker-compose >/dev/null 2>&1 || abort "docker-compose nao encontrado"
+get_dc_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+    elif command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+    else
+        return 1
+    fi
+}
+
+DC_CMD=$(get_dc_cmd) || abort "docker-compose nao encontrado"
 if [ -n "${RCLONE_REMOTE:-}" ]; then
     command -v rclone >/dev/null 2>&1 || abort "rclone nao encontrado"
 fi
@@ -24,7 +34,7 @@ mkdir -p "$BACKUP_DIR"
 DATE=$(date +%F-%H%M%S)
 FILE="$BACKUP_DIR/openemr-$DATE.sql"
 
-if docker-compose exec -T mysql mysqldump -u"${MYSQL_USER:-openemr}" -p"${MYSQL_PASS:-openemr}" openemr > "$FILE"; then
+if $DC_CMD exec -T mysql mysqldump -u"${MYSQL_USER:-openemr}" -p"${MYSQL_PASS:-openemr}" openemr > "$FILE"; then
     log "Backup criado em $FILE"
     if [ -n "${RCLONE_REMOTE:-}" ]; then
         if rclone copy "$FILE" "$RCLONE_REMOTE"; then

--- a/codex-env-setup.sh
+++ b/codex-env-setup.sh
@@ -23,7 +23,17 @@ if ! command -v docker >/dev/null; then
     apt-get install -y docker.io docker-compose
 fi
 
-command -v docker-compose >/dev/null || abort "docker-compose installation failed"
+get_dc_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+    elif command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+    else
+        return 1
+    fi
+}
+
+DC_CMD=$(get_dc_cmd) || abort "docker-compose installation failed"
 
 if ! systemctl is-active --quiet docker; then
     log "Starting Docker service..."
@@ -40,7 +50,7 @@ if [ ! -f .env ]; then
 fi
 
 log "Starting OpenEMR containers..."
-docker-compose up -d
+$DC_CMD up -d
 
 log "Waiting for containers to initialize..."
 sleep 30
@@ -49,4 +59,4 @@ log "OpenEMR is now accessible at:"
 log "- http://localhost"
 log "- https://localhost (self-signed certificate)"
 log "Default credentials: admin / pass"
-log "To stop the environment run: docker-compose down"
+log "To stop the environment run: $DC_CMD down"

--- a/log-monitor-openai.sh
+++ b/log-monitor-openai.sh
@@ -11,8 +11,21 @@ command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
 LOG_FILE="./logs/docker.log"
 mkdir -p ./logs
 
+get_dc_cmd() {
+  if docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose"
+  else
+    echo "docker-compose nao encontrado" >&2
+    exit 1
+  fi
+}
+
+DC_CMD=$(get_dc_cmd)
+
 echo "Collecting container logs..."
-docker-compose logs --no-color > "$LOG_FILE"
+$DC_CMD logs --no-color > "$LOG_FILE"
 
 # Take the last 200 lines for analysis
 LOG_DATA=$(tail -n 200 "$LOG_FILE" | sed 's/"/\\"/g')

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,17 @@ abort() {
     exit 1
 }
 
-command -v docker-compose >/dev/null 2>&1 || abort "docker-compose nao encontrado"
+get_dc_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+    elif command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+    else
+        return 1
+    fi
+}
+
+DC_CMD=$(get_dc_cmd) || abort "docker-compose nao encontrado"
 
 # Solicitar dados ao usuario
 read -rp "Domínio do OpenEMR (ex: openemr.example.com): " DOMAIN
@@ -34,7 +44,7 @@ for f in nginx/nginx.conf nginx/nginx-fallback.conf; do
 done
 
 log "Iniciando containers..."
-docker-compose up -d
+$DC_CMD up -d
 
 log "Aguardando inicializacao dos containers..."
 sleep 30
@@ -45,6 +55,6 @@ log "- OpenEMR HTTP (Producao): http://${DOMAIN}"
 log "- OpenEMR HTTPS (Local): https://localhost (certificado autoassinado - avisos do navegador)"
 log "- OpenEMR HTTPS (Producao): https://${DOMAIN} (certificado autoassinado - avisos do navegador)"
 log ""
-log "Para parar os containers: docker-compose down"
-log "Para ver logs: docker-compose logs -f"
-log "Para ver logs do nginx: docker-compose logs -f nginx"
+log "Para parar os containers: $DC_CMD down"
+log "Para ver logs: $DC_CMD logs -f"
+log "Para ver logs do nginx: $DC_CMD logs -f nginx"

--- a/ubuntu-setup.sh
+++ b/ubuntu-setup.sh
@@ -33,7 +33,17 @@ if ! systemctl is-active --quiet docker; then
     systemctl start docker
 fi
 
-command -v docker-compose >/dev/null 2>&1 || abort "docker-compose not found"
+get_dc_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+    elif command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+    else
+        return 1
+    fi
+}
+
+DC_CMD=$(get_dc_cmd) || abort "docker-compose not found"
 
 # Ensure .env exists
 if [ ! -f .env ]; then
@@ -52,6 +62,6 @@ if [ -x ./firewall-setup.sh ]; then
 fi
 
 log "Starting OpenEMR containers..."
-docker-compose up -d
+$DC_CMD up -d
 
 log "Setup complete. Access OpenEMR at http://localhost"

--- a/update.sh
+++ b/update.sh
@@ -12,15 +12,25 @@ abort() {
     exit 1
 }
 
-command -v docker-compose >/dev/null 2>&1 || abort "docker-compose nao encontrado"
+get_dc_cmd() {
+    if docker compose version >/dev/null 2>&1; then
+        echo "docker compose"
+    elif command -v docker-compose >/dev/null 2>&1; then
+        echo "docker-compose"
+    else
+        return 1
+    fi
+}
+
+DC_CMD=$(get_dc_cmd) || abort "docker-compose nao encontrado"
 
 log "Baixando ultimas imagens..."
-docker-compose pull
+$DC_CMD pull
 
 log "Criando backup do banco de dados antes do update..."
 "$(dirname "$0")/backup.sh"
 
 log "Aplicando atualizacoes..."
-docker-compose up -d --remove-orphans
+$DC_CMD up -d --remove-orphans
 
 log "Update completo."


### PR DESCRIPTION
## Summary
- support either `docker compose` plugin or legacy `docker-compose` in setup and utility scripts
- update workflow to use `docker compose`
- adjust log monitor to use the compose command helper

## Testing
- `bash run-tests.sh` *(fails: backup.sh tests did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_6840923108a08328a8285ea3ab36dac7