### PR TITLE
Fix docker-compose indentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     - ./ssl/openemr.key:/etc/ssl/private/openemr.key:ro
     - certbot_certs:/etc/letsencrypt
     - certbot_www:/var/www/certbot
-          - ./nginx/health.html:/opt/health_status/health.html:ro # New mount for health.html
+    - ./nginx/health.html:/opt/health_status/health.html:ro # New mount for health.html
     depends_on:
     - openemr
 


### PR DESCRIPTION
## Summary
- fix invalid Docker Compose volume entry due to stray indentation

## Testing
- `./run-tests.sh` *(fails: Running tests/backup.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68409f8c7fe483288c0e2de2d58765a8