### PR TITLE
Add PHP-FPM container

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ If you prefer to set things up manually:
    ./update.sh
    ```
    This pulls the latest images, creates a backup and restarts the services.
+6. The compose file also includes a `php-fpm` service. Place your PHP files in
+   the `./php` directory to have them served by this container.
 
 ## Backup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,12 @@ services:
     depends_on:
       - nginx
 
+  php-fpm:
+    image: php:8.2-fpm-alpine
+    restart: always
+    volumes:
+      - ./php:/var/www/html
+
 volumes:
   logvolume01: {}
   sitevolume: {}

--- a/php/index.php
+++ b/php/index.php
@@ -1,0 +1,1 @@
+<?php echo "PHP-FPM container running"; ?>


### PR DESCRIPTION
## Summary
- add `php-fpm` service to `docker-compose.yml`
- document new service in README
- include example `php/index.php`

## Testing
- `bash run-tests.sh` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840abedace88328ad7a349bfaa89bff