### PR TITLE
Improve interactive setup for OpenEMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This repository provides a simple Docker Compose configuration for [OpenEMR](htt
 ## Getting Started
 
 On Ubuntu systems you can run the helper script `ubuntu-setup.sh` to install
-Docker dependencies, configure the firewall and start the containers:
+Docker dependencies and start the containers. The script will ask for the
+domain name and the main environment variables before generating the `.env`
+file and optionally configuring the firewall:
 
 ```bash
 sudo ./ubuntu-setup.sh

--- a/tests/backup.sh
+++ b/tests/backup.sh
@@ -28,7 +28,7 @@ PATH="$(pwd)/$TMP/bin:$PATH" BACKUP_DIR="$(pwd)/$TMP/backups" MYSQL_USER=u MYSQL
 # Test: uploads backup when RCLONE_REMOTE is set
 cat <<STUB > "$TMP/bin/rclone"
 #!/bin/bash
-echo "$@" > "$TMP/rclone_args"
+echo "\$@" > "$TMP/rclone_args"
 exit 0
 STUB
 chmod +x "$TMP/bin/rclone"


### PR DESCRIPTION
## Summary
- enhance `ubuntu-setup.sh` with prompts for domain, DB credentials and optional firewall setup
- document new interactive script usage in `README.md`
- fix unit test for `backup.sh`

## Testing
- `./run-tests.sh`
- `shellcheck setup.sh update.sh backup.sh ubuntu-setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840ec9362b083289338b5028bae4e18