### PR TITLE
Fix Apache ServerName warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Run `./firewall-setup.sh` as root to open ports 80 and 443 for the Docker contai
 - Stop services: `docker-compose down`
 - View logs: `docker-compose logs -f`
 
+### Suppressing Apache ServerName Warning
+
+If you see a message like:
+
+```
+AH00558: httpd: Could not reliably determine the server's fully qualified domain name
+```
+
+Apache needs a `ServerName` directive. The compose file mounts
+`apache/servername.conf` into the OpenEMR container to set this to `localhost`.
+Edit that file if you want to use a different domain name.
+
 ## Troubleshooting 502 Bad Gateway
 A 502 response from Nginx usually means it cannot reach the OpenEMR container or the application failed to start.
 Check the following:

--- a/apache/servername.conf
+++ b/apache/servername.conf
@@ -1,0 +1,1 @@
+ServerName localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
     - logvolume01:/var/log
     - sitevolume:/var/www/localhost/htdocs/openemr/sites
+    - ./apache/servername.conf:/etc/apache2/conf.d/servername.conf:ro
     environment:
       MYSQL_HOST: mysql
       MYSQL_ROOT_PASS: ${MYSQL_ROOT_PASSWORD}


### PR DESCRIPTION
## Summary
- mount a custom `servername.conf` file into the OpenEMR container
- document how to change the `ServerName` setting

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840f39fee4c83288cd1d7ec3c42d382