### PR TITLE
Add optional CouchDB container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ MYSQL_USER=openemr
 MYSQL_PASS=troque_esta_senha
 OE_USER=admin
 OE_PASS=troque_esta_senha_admin
+# Credenciais para o CouchDB opcional
+#COUCHDB_USER=admin
+#COUCHDB_PASSWORD=troque_esta_senha_couch
 # Opcional: destino remoto rclone para backups
 # Exemplo: RCLONE_REMOTE=s3:meubucket/backups
 #RCLONE_REMOTE=

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ If you prefer to set things up manually:
    This pulls the latest images, creates a backup and restarts the services.
 6. The compose file also includes a `php-fpm` service. Place your PHP files in
    the `./php` directory to have them served by this container.
+7. A `couchdb` service is provided for modules that require CouchDB. Set
+   `COUCHDB_USER` and `COUCHDB_PASSWORD` in your `.env` file to enable it. The
+   database is exposed on port `5984`.
 
 ## Backup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,17 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
 
+  couchdb:
+    restart: always
+    image: couchdb:3
+    environment:
+      COUCHDB_USER: ${COUCHDB_USER}
+      COUCHDB_PASSWORD: ${COUCHDB_PASSWORD}
+    volumes:
+      - couchdb_data:/opt/couchdb/data
+    ports:
+      - 5984:5984
+
   openemr:
     restart: always
     image: openemr/openemr:7.0.3
@@ -64,3 +75,4 @@ volumes:
   databasevolume: {}
   certbot_certs: {}
   certbot_www: {}
+  couchdb_data: {}


### PR DESCRIPTION
## Summary
- add CouchDB service to docker-compose and volume
- document the CouchDB container
- add example environment variables

## Testing
- `bash run-tests.sh`
- `docker compose --env-file .env.example -f docker-compose.yml config` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840f4154ee48328a8593f530868058e