### PR TITLE
Disable io_uring warnings for MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ sudo ./ubuntu-setup.sh
 If you prefer to set things up manually:
 
 1. Copy `.env.example` to `.env` and set strong passwords for the database and initial OpenEMR user.
+   The MySQL service uses the configuration file `./mysql/my.cnf` which disables
+   `io_uring` and native AIO. This prevents warnings such as `io_uring_queue_init()
+   failed with EPERM` on hosts where these features are restricted.
 2. Start the services:
    ```bash
    docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     volumes:
     - databasevolume:/var/lib/mysql
+    - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf:ro
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
 

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+innodb_use_native_aio=0
+innodb_use_io_uring=0


### PR DESCRIPTION
## Summary
- mount a custom MariaDB config file
- document the new config file in README

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840f4758ba0832897243cfde535df1f