### PR TITLE
Add CouchDB setup options

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,10 @@ read -rp "Senha do MySQL root: " MYSQL_ROOT_PASSWORD
 read -rp "Senha do MySQL para o usuário openemr: " MYSQL_PASS
 read -rp "Usuário inicial do OpenEMR: " OE_USER
 read -rp "Senha inicial do OpenEMR: " OE_PASS
+read -rp "Usuário do CouchDB (opcional): " COUCHDB_USER
+if [ -n "$COUCHDB_USER" ]; then
+    read -rp "Senha do CouchDB: " COUCHDB_PASSWORD
+fi
 
 MYSQL_USER="openemr"
 
@@ -38,6 +42,13 @@ MYSQL_PASS=${MYSQL_PASS}
 OE_USER=${OE_USER}
 OE_PASS=${OE_PASS}
 EOFENV
+
+if [ -n "${COUCHDB_USER:-}" ]; then
+cat >> .env <<EOFENV
+COUCHDB_USER=${COUCHDB_USER}
+COUCHDB_PASSWORD=${COUCHDB_PASSWORD}
+EOFENV
+fi
 
 for f in nginx/nginx.conf nginx/nginx-fallback.conf; do
     sed -i "s/openemr.example.com/${DOMAIN}/g" "$f"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -29,6 +29,7 @@ root
 dbpass
 admin
 adminpass
+
 EOF
 grep -q "Containers iniciados" "$TMP/out"
 

--- a/ubuntu-setup.sh
+++ b/ubuntu-setup.sh
@@ -22,6 +22,10 @@ read -rp "Senha do MySQL root: " MYSQL_ROOT_PASSWORD
 read -rp "Senha do MySQL para o usuário openemr: " MYSQL_PASS
 read -rp "Usuário inicial do OpenEMR: " OE_USER
 read -rp "Senha inicial do OpenEMR: " OE_PASS
+read -rp "Usuário do CouchDB (opcional): " COUCHDB_USER
+if [ -n "$COUCHDB_USER" ]; then
+    read -rp "Senha do CouchDB: " COUCHDB_PASSWORD
+fi
 read -rp "Destino rclone para backups (opcional): " RCLONE_REMOTE
 
 log "Updating package index..."
@@ -63,6 +67,12 @@ MYSQL_PASS=${MYSQL_PASS}
 OE_USER=${OE_USER}
 OE_PASS=${OE_PASS}
 EOF
+if [ -n "${COUCHDB_USER:-}" ]; then
+    cat >> .env <<EOF
+COUCHDB_USER=${COUCHDB_USER}
+COUCHDB_PASSWORD=${COUCHDB_PASSWORD}
+EOF
+fi
 if [ -n "${RCLONE_REMOTE}" ]; then
     echo "RCLONE_REMOTE=${RCLONE_REMOTE}" >> .env
 fi


### PR DESCRIPTION
## Summary
- prompt for CouchDB credentials in `setup.sh`
- prompt for CouchDB credentials in `ubuntu-setup.sh`
- adjust tests for the new input

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840fc46bf7c8328a2aed23750668c67