### PR TITLE
Add OpenEMR monitor script to setup

### DIFF
--- a/openemr-env-installer.md
+++ b/openemr-env-installer.md
@@ -36,4 +36,20 @@ bash openemr-env-installer /home/test/code testuser
    * 2GB of free memory
    * 20GB of free disk space
    * Internet connection
-   * A container or virtual machine manager such as Docker, Hyperkit, Hyper-V, KVM, Parallels, Podman, VirtualBox or VMWare.
+    * A container or virtual machine manager such as Docker, Hyperkit, Hyper-V, KVM, Parallels, Podman, VirtualBox or VMWare.
+
+## Optional: Install the OpenEMR Monitor
+
+The [OpenEMR Monitor](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-monitor)
+provides a Prometheus and Grafana based environment for monitoring your
+containers. To download the monitor installer and set it up, run:
+
+```bash
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/monitor-installer > monitor-installer
+chmod +x monitor-installer
+./monitor-installer <install dir> <host ip> <smtp server:port> <sender email> <sender password> <receiver email>
+```
+
+Replace the arguments with the desired installation directory and your email
+settings. The script will download the necessary Compose files and print
+instructions to start the monitoring stack.

--- a/setup.sh
+++ b/setup.sh
@@ -79,3 +79,12 @@ if [ -f utilities/openemr-cmd ]; then
     chmod +x "$TARGET_DIR/openemr-cmd" "$TARGET_DIR/openemr-cmd-h"
     log "Utilitários 'openemr-cmd' instalados em $TARGET_DIR"
 fi
+
+# Install health_monitor.sh for system monitoring
+if [ -f health_monitor.sh ]; then
+    TARGET_DIR="$HOME/.local/bin"
+    mkdir -p "$TARGET_DIR"
+    cp health_monitor.sh "$TARGET_DIR/"
+    chmod +x "$TARGET_DIR/health_monitor.sh"
+    log "Script 'health_monitor.sh' instalado em $TARGET_DIR"
+fi

--- a/ubuntu-setup.sh
+++ b/ubuntu-setup.sh
@@ -108,3 +108,12 @@ if [ -f utilities/openemr-cmd ]; then
     log "Utilitários 'openemr-cmd' instalados em $TARGET_DIR"
 fi
 
+# Install health_monitor.sh for system monitoring
+if [ -f health_monitor.sh ]; then
+    TARGET_DIR="$HOME/.local/bin"
+    mkdir -p "$TARGET_DIR"
+    cp health_monitor.sh "$TARGET_DIR/"
+    chmod +x "$TARGET_DIR/health_monitor.sh"
+    log "Script 'health_monitor.sh' instalado em $TARGET_DIR"
+fi
+


### PR DESCRIPTION
## Summary
- install `health_monitor.sh` in `setup.sh` and `ubuntu-setup.sh`
- document how to install the Prometheus-based OpenEMR Monitor in `openemr-env-installer.md`

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841c06973cc8328aa137c3d28346033