### PR TITLE
Sanitize repo domain references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # Variaveis de ambiente para OpenEMR
 # Copie este arquivo para .env e defina senhas seguras
-MYSQL_ROOT_PASSWORD=troque_esta_senha_root
+# Valores "change_me" devem ser substituidos durante a instalacao
+MYSQL_ROOT_PASSWORD=change_me_root
 MYSQL_USER=openemr
-MYSQL_PASS=troque_esta_senha
+MYSQL_PASS=change_me
 OE_USER=admin
-OE_PASS=troque_esta_senha_admin
+OE_PASS=change_me_admin
 # Credenciais para o CouchDB opcional
 #COUCHDB_USER=admin
 #COUCHDB_PASSWORD=troque_esta_senha_couch

--- a/README-Ophthalmology.md
+++ b/README-Ophthalmology.md
@@ -3,7 +3,7 @@
 ## Instalação e Configuração
 
 ### 1. Prerequisites
-- A domain name (e.g., `openemr.example.com`) pointing to your server's public IP address.
+- A domain name (e.g., `seu.dominio.com`) pointing to your server's public IP address.
 - Ports 80 and 443 open on your server.
 
 ### 2. Initial Setup Script
@@ -17,11 +17,11 @@ This will start all services defined in `docker-compose.yml`.
 This setup uses Let's Encrypt for SSL certificates. After running the setup script (or `docker-compose up -d`):
 
    **a. Obtain Initial Certificate:**
-   Run the following command, replacing `philipe_cruz@outlook.com` with your email:
+   Run the following command, replacing `you@example.com` with your email:
    ```bash
    docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot \
-       --email philipe_cruz@outlook.com --agree-tos --no-eff-email \
-       -d openemr.example.com
+       --email you@example.com --agree-tos --no-eff-email \
+       -d <YOUR_DOMAIN>
    ```
 
    **b. Restart Nginx:**
@@ -39,21 +39,21 @@ This setup uses Let's Encrypt for SSL certificates. After running the setup scri
    ```
 
 ### 4. Acesso ao Sistema
-- **URL HTTPS**: `https://openemr.example.com` (Recomendado para produção; usa Let's Encrypt)
-- **URL HTTP**: `http://openemr.example.com` (Produção) ou `http://localhost` (Local/desenvolvimento)
+- **URL HTTPS**: `https://<YOUR_DOMAIN>` (Recomendado para produção; usa Let's Encrypt)
+- **URL HTTP**: `http://<YOUR_DOMAIN>` (Produção) ou `http://localhost` (Local/desenvolvimento)
 - **Usuário**: admin
 - **Senha**: pass
 
-**Nota sobre `https://localhost`**: Acessar `https://localhost` provavelmente mostrará avisos de certificado, pois o certificado Let's Encrypt é para `openemr.example.com`. Para acesso local, prefira `http://localhost`.
+**Nota sobre `https://localhost`**: Acessar `https://localhost` provavelmente mostrará avisos de certificado, pois o certificado Let's Encrypt é emitido para `<YOUR_DOMAIN>`. Para acesso local, prefira `http://localhost`.
 
 ## Segurança SSL/HTTPS (Let's Encrypt)
 
 ### Características de Segurança:
-- **Let's Encrypt Certificates**: Trusted SSL certificates for `openemr.example.com`.
+- **Let's Encrypt Certificates**: Trusted SSL certificates for `<YOUR_DOMAIN>`.
 - **Automated Renewal**: Certbot service automatically renews certificates.
 - **Protocolos seguros** TLS 1.2 e 1.3.
 - **Headers de segurança** configurados.
-- **Content Security Policy (CSP)**: `upgrade-insecure-requests` para `https://openemr.example.com` para ajudar a prevenir conteúdo misto.
+- **Content Security Policy (CSP)**: `upgrade-insecure-requests` para `https://<YOUR_DOMAIN>` para ajudar a prevenir conteúdo misto.
 - **Proxy reverso nginx** for managing SSL and serving OpenEMR.
 
 ### For Production:
@@ -147,7 +147,7 @@ echo "Restauração concluída"
 ## Próximos Passos
 
 1. Complete os passos de geração inicial de certificados descritos acima.
-2. Acesse o OpenEMR em `https://openemr.example.com` e conclua o assistente de configuração.
+2. Acesse o OpenEMR em `https://<YOUR_DOMAIN>` e conclua o assistente de configuração.
 3. Configure os usuários específicos da clínica.
 4. O script de instalação já baixa e instala automaticamente o módulo **Eye Exam** e os templates oftalmológicos.
 5. Configure o agendamento para diferentes tipos de consulta.

--- a/README-pt_BR.md
+++ b/README-pt_BR.md
@@ -57,10 +57,10 @@ Se preferir configurar manualmente:
    ```bash
 docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot \
     --email you@example.com --agree-tos --no-eff-email \
-    -d openemr.example.com
+    -d <SEU_DOMINIO>
 docker-compose restart nginx
    ```
-4. Acesse `https://openemr.example.com` e complete o assistente de instalação.
+4. Acesse `https://<SEU_DOMINIO>` e complete o assistente de instalação.
 5. Para manter a instalação atualizada, execute:
    ```bash
    ./update.sh

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ If you prefer to set things up manually:
    ```bash
    docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot \
        --email you@example.com --agree-tos --no-eff-email \
-       -d openemr.example.com
+       -d <YOUR_DOMAIN>
    docker-compose restart nginx
    ```
-4. Access `https://openemr.example.com` and complete the setup wizard.
+4. Access `https://<YOUR_DOMAIN>` and complete the setup wizard.
 5. To keep your installation up to date run:
    ```bash
    ./update.sh

--- a/knowledge.md
+++ b/knowledge.md
@@ -12,8 +12,8 @@ This project sets up OpenEMR for a generic ophthalmology clinic using Docker Com
 The system is currently configured to use **self-signed certificates** for immediate HTTPS access. This allows both HTTP and HTTPS to work without requiring Let's Encrypt setup.
 
 **Current Access URLs:**
-- **HTTP**: `http://localhost` (Local) or `http://openemr.example.com` (Production)
-- **HTTPS**: `https://localhost` or `https://openemr.example.com` (Uses self-signed certificates - browsers will show security warnings)
+- **HTTP**: `http://localhost` (Local) or `http://<YOUR_DOMAIN>` (Production)
+- **HTTPS**: `https://localhost` or `https://<YOUR_DOMAIN>` (Uses self-signed certificates - browsers will show security warnings)
 
 **Configuration Details:**
 - Uses `nginx-fallback.conf` which includes self-signed certificates
@@ -26,7 +26,7 @@ The system is currently configured to use **self-signed certificates** for immed
 To upgrade to Let's Encrypt certificates (for production without browser warnings):
 
 **Prerequisites:**
-- The domain `openemr.example.com` must have its DNS A record pointing to the public IP address of the server.
+- The domain `<YOUR_DOMAIN>` must have its DNS A record pointing to the public IP address of the server.
 - Port 80 and 443 must be open on the server.
 
 **Steps to Enable Let's Encrypt:**
@@ -41,8 +41,8 @@ To upgrade to Let's Encrypt certificates (for production without browser warning
 2. **Run Certbot to Obtain the Certificate:**
    ```bash
    docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot \
-       --email philipe_cruz@outlook.com --agree-tos --no-eff-email \
-       -d openemr.example.com
+       --email you@example.com --agree-tos --no-eff-email \
+       -d <YOUR_DOMAIN>
    ```
 
 3. **Restart Nginx:**

--- a/nginx/nginx-fallback.conf
+++ b/nginx/nginx-fallback.conf
@@ -7,11 +7,11 @@ http {
         server openemr:80;
     }
 
-    # Server block for openemr.example.com on port 80
+    # Server block for __DOMAIN__ on port 80
     # Handles ACME challenges and serves HTTP
     server {
         listen 80;
-        server_name openemr.example.com;
+        server_name __DOMAIN__;
 
         # ACME challenge handler
         location /.well-known/acme-challenge/ {
@@ -66,7 +66,7 @@ http {
     # HTTPS server using self-signed certificates
     server {
         listen 443 ssl;
-        server_name openemr.example.com localhost;
+        server_name __DOMAIN__ localhost;
 
         # Self-signed certificates
         ssl_certificate /etc/ssl/certs/openemr.crt;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,11 +7,11 @@ http {
         server openemr:80;
     }
 
-    # Server block for openemr.example.com on port 80
+    # Server block for __DOMAIN__ on port 80
     # Handles ACME challenges and serves HTTP
     server {
         listen 80;
-        server_name openemr.example.com;
+        server_name __DOMAIN__;
 
         # ACME challenge handler
         location /.well-known/acme-challenge/ {
@@ -61,15 +61,15 @@ http {
         }
     }
 
-    # HTTPS server (for openemr.example.com)
+    # HTTPS server (for __DOMAIN__)
     # Uses self-signed certificates as fallback, can be upgraded to Let's Encrypt later
     server {
         listen 443 ssl;
-        server_name openemr.example.com;
+        server_name __DOMAIN__;
 
         # Try Let's Encrypt certificates first, fallback to self-signed
-        ssl_certificate /etc/letsencrypt/live/openemr.example.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/openemr.example.com/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/__DOMAIN__/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/__DOMAIN__/privkey.pem;
 
         # Fallback to self-signed certificates if Let's Encrypt not available
         # ssl_certificate /etc/ssl/certs/openemr.crt;

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ install_ophthalmology_modules() {
 
 
 # Solicitar dados ao usuario
-read -rp "Domínio do OpenEMR (ex: openemr.example.com): " DOMAIN
+read -rp "Domínio do OpenEMR (ex: seu.dominio.com): " DOMAIN
 read -rp "Senha do MySQL root: " MYSQL_ROOT_PASSWORD
 read -rp "Senha do MySQL para o usuário openemr: " MYSQL_PASS
 read -rp "Usuário inicial do OpenEMR: " OE_USER
@@ -72,7 +72,7 @@ EOFENV
 fi
 
 for f in nginx/nginx.conf nginx/nginx-fallback.conf; do
-    sed -i "s/openemr.example.com/${DOMAIN}/g" "$f"
+    sed -i "s/__DOMAIN__/${DOMAIN}/g" "$f"
 done
 
 log "Iniciando containers..."

--- a/ubuntu-setup.sh
+++ b/ubuntu-setup.sh
@@ -58,7 +58,7 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 # Prompt for configuration values
-read -rp "Domínio do OpenEMR (ex: openemr.example.com): " DOMAIN
+read -rp "Domínio do OpenEMR (ex: seu.dominio.com): " DOMAIN
 read -rp "Senha do MySQL root: " MYSQL_ROOT_PASSWORD
 read -rp "Senha do MySQL para o usuário openemr: " MYSQL_PASS
 read -rp "Usuário inicial do OpenEMR: " OE_USER
@@ -142,7 +142,7 @@ fi
 
 # Replace domain in Nginx configs
 for f in nginx/nginx.conf nginx/nginx-fallback.conf; do
-    sed -i "s/openemr.example.com/${DOMAIN}/g" "$f"
+    sed -i "s/__DOMAIN__/${DOMAIN}/g" "$f"
 done
 
 # Apply basic firewall rules if requested


### PR DESCRIPTION
## Summary
- scrub example domain references from docs and configs
- prompt for domain/user/password during codex env setup
- use placeholder domain in nginx configs and installation scripts
- update example environment file with placeholder values

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686318c3e62c8328b5751d54a3891109